### PR TITLE
Better context handling

### DIFF
--- a/context_key.go
+++ b/context_key.go
@@ -13,6 +13,12 @@ var ContextKeyBase = "vial."
 // This is the key that the Sequence ID is stored under in the context.
 var SequenceIdContextKey = ContextKey("sequence_id")
 
+// This is the key that the server's logger is stored under.
+var ServerLoggerContextKey = ContextKey("server.logger")
+
+// This is the key that the transactor will live under in the request context.
+var TransactorContextKey = ContextKey("transactor")
+
 // ContextKey is a helper for generating a context key prefixed for vial.
 func ContextKey(key string) string {
     return ContextKeyBase + key

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package vial
 
 import (
+    "context"
     "net/http"
 
     "github.com/google/uuid"
@@ -10,6 +11,15 @@ import (
 type InboundRequest struct {
     http.Request
     PathParams PathParams
+}
+
+
+// WithContext returns a new InboundRequest with the provided context.
+func (r InboundRequest) WithContext(ctx context.Context) *InboundRequest {
+    return &InboundRequest{
+        Request: *r.Request.WithContext(ctx),
+        PathParams: r.PathParams,
+    }
 }
 
 // PathString returns a variable from the path matching the provided key as

--- a/responses/builder.go
+++ b/responses/builder.go
@@ -220,6 +220,12 @@ func (self *Builder) Finish(additionals ...AdditionalAttribute) Data {
     return *self.prepare(additionals)
 }
 
+// ChangeContext changes the existing context on the builder to the
+// provided one. Use this with caution.
+func (self *Builder) ChangeContext(ctx context.Context) {
+    self.ctx = ctx
+}
+
 // NewBuilder generates a new builder to help generate a response Data struct.
 func NewBuilder(
     ctx context.Context,

--- a/server_test.go
+++ b/server_test.go
@@ -141,7 +141,7 @@ func TestServerBasic(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Header().Get("Sequence-Id")).ToNot(gm.BeEmpty())
@@ -168,7 +168,7 @@ func TestServerBasicEncrypted(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Header().Get("Sequence-Id")).ToNot(gm.BeEmpty())
@@ -222,7 +222,7 @@ func TestServerFuncMultiRoute(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Header().Get("Sequence-Id")).ToNot(gm.BeEmpty())
@@ -231,7 +231,7 @@ func TestServerFuncMultiRoute(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req2)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Header().Get("Sequence-Id")).ToNot(gm.BeEmpty())
@@ -279,7 +279,7 @@ func TestServerSimpleRoute(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Header().Get("Sequence-Id")).ToNot(gm.BeEmpty())
@@ -323,7 +323,7 @@ func TestServerDefaultOptions(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Header().Get("Access-Control-Allow-Methods")).To(
         gm.Equal("OPTIONS, GET, POST"),
     )
@@ -343,7 +343,7 @@ func TestServerBadMethod(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     t.Log(rr.Body.String())
     g.Expect(rr.Code).To(gm.Equal(http.StatusMethodNotAllowed))
     g.Expect(rr.Header().Get("Allow")).To(
@@ -365,7 +365,7 @@ func TestServerBasicGoStart(t *testing.T) {
         t.Log("S resp", resp)
         switch resp.Type {
             case ServerStartChannelResponse:
-            time.Sleep(10)
+            time.Sleep(1 * time.Millisecond)
             err := server.Stop()
             g.Expect(err).To(gm.BeNil())
             continue
@@ -396,7 +396,7 @@ func TestServerEncryptedGoStart(t *testing.T) {
         t.Log("S resp", resp)
         switch resp.Type {
             case ServerStartChannelResponse:
-            time.Sleep(10)
+            time.Sleep(1 * time.Millisecond)
             err := server.Stop()
             g.Expect(err).To(gm.BeNil())
             continue
@@ -440,7 +440,7 @@ func TestServerMissingRoute(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusNotFound))
     // TODO: Need to make sequence ids return always. This requires somehow
     // hijacking the default 404 handler. It will take some work. It might
@@ -488,7 +488,7 @@ func TestServerPreActionModifyContext(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(`{"context_value":"bar"}`))
 }
@@ -517,7 +517,7 @@ func TestServerPreActionHijackReturn(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(`HIJACKED!`))
 }
@@ -551,7 +551,7 @@ func TestServerPostActionHijackReturn(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Code).To(gm.Equal(http.StatusAccepted))
 }
@@ -587,7 +587,7 @@ func TestServerBasicEncryptedFilePaths(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Header().Get("Sequence-Id")).ToNot(gm.BeEmpty())
@@ -632,7 +632,7 @@ func TestServerBasicEncryptedFilePathsViaConfig(t *testing.T) {
 
     server.muxer.ServeHTTP(rr, req)
 
-    t.Log(rr.HeaderMap)
+    t.Log(rr.Result().Header)
     g.Expect(rr.Code).To(gm.Equal(http.StatusOK))
     g.Expect(rr.Body.String()).To(gm.Equal(expectedBody))
     g.Expect(rr.Header().Get("Sequence-Id")).ToNot(gm.BeEmpty())

--- a/transactor_options.go
+++ b/transactor_options.go
@@ -10,8 +10,8 @@ type TransactorOption func(*Transactor) error
 // WithExistingContext creates a transactor using the existing context which
 // overrides the default `request.Context()`.
 func WithExistingContext(existingCtx context.Context) TransactorOption {
-    return func(ctx *Transactor) error {
-        ctx.context = existingCtx
+    return func(transactor *Transactor) error {
+        transactor.ChangeContext(existingCtx)
 
         return nil
     }


### PR DESCRIPTION
- Add WithContext to InboundRequest.
- Add ChangeContext to Transactor & Builder.
- Add default context value of `vial.transactor` which yields a pointer to the transactor.
- Add default context value of `vial.server.logger` which yields a pointer to the server-level logger.